### PR TITLE
add support for projects with multiple markdown files.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -277,3 +277,6 @@ compress_html:
     envs: development
 
 github: [metadata]
+
+# site var to make array creation easier
+emptyArray: []

--- a/docs/_docs/05-projects.md
+++ b/docs/_docs/05-projects.md
@@ -6,7 +6,26 @@ author_profile: false
 ---
 
 <div class="grid__wrapper">
-  {% for post in site.projects %}
+
+  {% assign projects = site.emptyArray %}
+  
+  {% for project in site.projects %}
+    
+    {% comment %} Collect all the multi-part projects based on the presence of the part attribute of the file {% endcomment %}
+    {% if project.part != nil and project.part == 1 %}
+      {% assign projects = projects | push: project %}
+      
+    {% comment %} Collect all the single page projects {% endcomment %}
+    {% elsif project.part == nil %}
+      {% assign projects = projects | push: project %}
+
+    {% endif %}
+
+  {% endfor %}
+  
+
+  {% for post in projects %}
     {% include archive-single.html type="grid" %}
   {% endfor %}
+  
 </div>


### PR DESCRIPTION
This allows projects to have multiple markdown files.  Create a new folder under the _projects folder and add the projects markdown files. Modify each file's markdown header to include a `part` attribute with the part number, e.g. [1, 2, 3, 4, ... ] - the first `part` of each project folder will be used to populate the project gallery.  