### PR TITLE
Add support for multi-page projects, resolving issue #155.

### DIFF
--- a/docs/_docs/05-projects.md
+++ b/docs/_docs/05-projects.md
@@ -6,7 +6,26 @@ author_profile: false
 ---
 
 <div class="grid__wrapper">
-  {% for post in site.projects %}
+
+  {% assign projects = site.emptyArray %}
+  
+  {% for project in site.projects %}
+    
+    {% comment %} Collect all the multi-part projects based on the presence of the part attribute of the file {% endcomment %}
+    {% if project.part != nil and project.part == 1 %}
+      {% assign projects = projects | push: project %}
+      
+    {% comment %} Collect all the single page projects {% endcomment %}
+    {% elsif project.part == nil %}
+      {% assign projects = projects | push: project %}
+
+    {% endif %}
+
+  {% endfor %}
+  
+
+  {% for post in projects %}
     {% include archive-single.html type="grid" %}
   {% endfor %}
+  
 </div>


### PR DESCRIPTION
This adds support for using a `part` attribute on project markdown headers to only display the first part of the multi-part project on the projects page.