### PR TITLE
Missed Entity Path

### DIFF
--- a/docs/_projects/09-air-traffic-control-simulator/08-air-traffic-control-simulator-04.md
+++ b/docs/_projects/09-air-traffic-control-simulator/08-air-traffic-control-simulator-04.md
@@ -112,7 +112,7 @@ In [Lab 2]({{"/docs/projects/air-traffic-control-simulator-02/" | absolute_url }
 1. Open **local.settings.json** and insert the following statement directly below   "EventHubConnection:"
 
 	```json
-	 "SharedEventHubConnection": "SHARED_EVENT_HUB_ENDPOINT",
+	 "SharedEventHubConnection": "SHARED_EVENT_HUB_ENDPOINT;EntityPath=flysim-shared-input-hub",
 	```
 
 1. Navigate to the Gist URL you created in [Lab 3]({{"/docs/projects/air-traffic-control-simulator-03/" | absolute_url }}) (for example, https://gist.github.com/scottgu) and copy the connection string from the public gist to the clipboard. Leave the browser window open so you can easily retrieve this connection string again.


### PR DESCRIPTION
Entity path is missed in azure function, we need it if we want redirect data to stream analytics matched with event hubs created in lab 3(cloudcity), when azure function is deployed without it return failure.