### PR TITLE
Inconsistency between node versions of npm and yarn. 

### DIFF
--- a/docs/_docs/03-faq.md
+++ b/docs/_docs/03-faq.md
@@ -53,12 +53,14 @@ brew doctor
 
 ![Homebrew doctor]({{"/assets/images/faq/brew-doctor.png" | absolute_url }})
 
-### Inconsistency between node versions of npm and yarn.
+### Inconsistency between node versions of npm and Yarn.
 
-When you run `install.sh` to install development environment on macOS. You may get a node incompatible error:
+When you run `install.sh` to install development environment on macOS, you may get a node incompatible error:
 
+```
 The engine "node" is incompatible with this module. Expected version ">= 8".
 Found incompatible module
+```
 
 To resolve, please upgrade node to the latest version.
 

--- a/docs/_docs/03-faq.md
+++ b/docs/_docs/03-faq.md
@@ -53,6 +53,21 @@ brew doctor
 
 ![Homebrew doctor]({{"/assets/images/faq/brew-doctor.png" | absolute_url }})
 
+### Node incompatible error on macOS.
+
+When you run `install.sh` to install development environment on macOS. You may get a node incompatible error:
+
+The engine "node" is incompatible with this module. Expected version ">= 8".
+Found incompatible module
+
+To resolve, follow the instruction of Homebrew by running:
+
+```bash
+brew update
+brew upgrade node
+npm install -g npm
+```
+
 ### Windows Defender SmartScreen prevented an unrecognized app error.
 
 Sometimes SmartScreen prevents applications you know are not bad – for example, it’s a CMD or VBS script.

--- a/docs/_docs/03-faq.md
+++ b/docs/_docs/03-faq.md
@@ -53,20 +53,14 @@ brew doctor
 
 ![Homebrew doctor]({{"/assets/images/faq/brew-doctor.png" | absolute_url }})
 
-### Node incompatible error on macOS.
+### Inconsistency between node versions of npm and yarn.
 
 When you run `install.sh` to install development environment on macOS. You may get a node incompatible error:
 
 The engine "node" is incompatible with this module. Expected version ">= 8".
 Found incompatible module
 
-To resolve, follow the instruction of Homebrew by running:
-
-```bash
-brew update
-brew upgrade node
-npm install -g npm
-```
+To resolve, please upgrade node to the latest version.
 
 ### Windows Defender SmartScreen prevented an unrecognized app error.
 


### PR DESCRIPTION
When  run `install.sh` to install development environment on macOS. may get a node incompatible error, so add some comments to reminder user to upgrade node version.