### PR TITLE
Change semantics and rendering of share section (social links)

### DIFF
--- a/docs/_includes/social-share-inline.html
+++ b/docs/_includes/social-share-inline.html
@@ -1,18 +1,17 @@
 <section class="page__share__inline">
-  <p>Reach us at</p>
-  <a href="http://gitter.im/Microsoft/azure-iot-developer-kit">
-    <img src="https://badges.gitter.im/iot-devkit.svg" alt="Join Gitter chat" style="height:25px">
-  </a>
-
-  <p>, get support at</p>
-  <a href="https://stackoverflow.com/questions/tagged/iot-devkit" target="_blank">
-    <img src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-logo.svg" alt="Get help from Stack Olverflow" style="width:150px; height:37px">
-  </a>
-
-  <p>or share us on</p>
-  <div style="display: inline-block">
-    <a href="https://twitter.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username }}&{% endif %}text={{ page.title }} {{ page.url | absolute_url }}" class="btn btn--twitter" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Twitter"><i class="fa fa-fw fa-twitter" aria-hidden="true"></i></a>
-    <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url }}" class="btn btn--facebook" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Facebook"><i class="fa fa-fw fa-facebook" aria-hidden="true"></i></a>
-    <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url }}" class="btn btn--linkedin" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fa fa-fw fa-linkedin" aria-hidden="true"></i></a>
-  </div>
+  <p>Reach us at
+      <a href="http://gitter.im/Microsoft/azure-iot-developer-kit" target="_blank">
+        <img src="https://badges.gitter.im/iot-devkit.svg" alt="Join Gitter chat" style="height:25px">
+        <span class="screen-reader-text">Gitter</span>
+      </a>, get support at
+      <a href="https://stackoverflow.com/questions/tagged/iot-devkit" target="_blank">
+        <img src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-logo.svg" alt="Get help from Stack Overflow" style="width:150px; height:37px">
+        <span class="screen-reader-text">Stack Overflow</span>
+      </a> or share us on
+      <span class="social-icons-list">
+        <a href="https://twitter.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username }}&{% endif %}text={{ page.title }} {{ page.url | absolute_url }}" class="btn btn--twitter" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Twitter"><i class="fa fa-fw fa-twitter" aria-hidden="true"></i><span class="screen-reader-text">Twitter</span></a>
+        <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url }}" class="btn btn--facebook" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Facebook"><i class="fa fa-fw fa-facebook" aria-hidden="true"></i><span class="screen-reader-text">Facebook</span></a>
+        <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url }}" class="btn btn--linkedin" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fa fa-fw fa-linkedin" aria-hidden="true"></i><span class="screen-reader-text">LinkedIn</span></a>
+      </span>
+  </p>
 </section>

--- a/docs/_includes/social-share.html
+++ b/docs/_includes/social-share.html
@@ -1,22 +1,17 @@
 <section class="page__share">
-  <div>
-    <p>Reach us at</p>
-    <a href="http://gitter.im/Microsoft/azure-iot-developer-kit" target="_blank">
-      <img src="https://badges.gitter.im/iot-devkit.svg" alt="Join Gitter chat" style="height:25px">
-    </a>
-
-    <p>, get support at</p>
-    <a href="https://stackoverflow.com/questions/tagged/iot-devkit" target="_blank">
-      <img src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-logo.svg" alt="Get help from Stack Olverflow" style="width:150px; height:37px">
-    </a>
-  </div>
-
-  <div>
-    <p>Or share us on</p>
-    <div style="display: inline-block">
-      <a href="https://twitter.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username }}&{% endif %}text={{ page.title }} {{ page.url | absolute_url }}" class="btn btn--twitter" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Twitter"><i class="fa fa-fw fa-twitter" aria-hidden="true"></i></a>
-      <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url }}" class="btn btn--facebook" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Facebook"><i class="fa fa-fw fa-facebook" aria-hidden="true"></i></a>
-      <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url }}" class="btn btn--linkedin" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fa fa-fw fa-linkedin" aria-hidden="true"></i></a>
-    </div>
-  </div>
+  <p>Reach us at
+      <a href="http://gitter.im/Microsoft/azure-iot-developer-kit" target="_blank">
+        <img src="https://badges.gitter.im/iot-devkit.svg" alt="Join Gitter chat" style="height:25px">
+        <span class="screen-reader-text">Gitter</span>
+      </a>, get support at
+      <a href="https://stackoverflow.com/questions/tagged/iot-devkit" target="_blank">
+        <img src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-logo.svg" alt="Get help from Stack Overflow" style="width:150px; height:37px">
+        <span class="screen-reader-text">Stack Overflow</span>
+      </a> or share us on
+      <span class="social-icons-list">
+        <a href="https://twitter.com/intent/tweet?{% if site.twitter.username %}via={{ site.twitter.username }}&{% endif %}text={{ page.title }} {{ page.url | absolute_url }}" class="btn btn--twitter" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Twitter"><i class="fa fa-fw fa-twitter" aria-hidden="true"></i><span class="screen-reader-text">Twitter</span></a>
+        <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url }}" class="btn btn--facebook" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} Facebook"><i class="fa fa-fw fa-facebook" aria-hidden="true"></i><span class="screen-reader-text">Facebook</span></a>
+        <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ page.url | absolute_url }}" class="btn btn--linkedin" title="{{ site.data.ui-text[site.locale].share_on_label | default: 'Share on' }} LinkedIn"><i class="fa fa-fw fa-linkedin" aria-hidden="true"></i><span class="screen-reader-text">LinkedIn</span></a>
+      </span>
+  </p>
 </section>

--- a/docs/_sass/minimal-mistakes/_page.scss
+++ b/docs/_sass/minimal-mistakes/_page.scss
@@ -301,7 +301,6 @@
 }
 
 .page__share__inline {
-  text-align: center;
   padding-bottom: 40px;
 
   @include breakpoint(max-width $small) {
@@ -318,11 +317,27 @@
   }
 }
 
-.page__share__inline a,.page__share__inline p {
+.page__share__inline,
+.page__share {
+  p {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    margin: 0 5px;
+  }
+  a {
     margin: 0 5px;
     display: inline-block;
+    vertical-align: center;
+  }
+  .social-icons-list {
+    display: flex;
+    justify-content: space-between;
+    margin-left: 5px;
+  }
 }
-
 
 /*
    Page meta


### PR DESCRIPTION
- single natural language text
- layout elements in vertical and horizontal axis using flexbox for better
vertical position
- typos in Stack Overflow name

Thanks!

The rendered text: 
```txt
 Reach us at Gitter, get support at Stack Overflow or share us on Twitter Facebook LinkedIn
```

Before:
![image](https://user-images.githubusercontent.com/14539/35300302-4e5ffcec-0088-11e8-853a-ad26053ea77d.png)
After:
![image](https://user-images.githubusercontent.com/14539/35300531-febcb71a-0088-11e8-8c56-406cca05fc9a.png)

