### PR TITLE
Refactor follow links semantics to use element with header/title role 

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,22 +1,23 @@
   <div class="page__footer-follow">
-  <ul class="social-icons">
+
+  <dl class="social-icons">
     {% if site.data.ui-text[site.locale].follow_label %}
-      <li><strong>{{ site.data.ui-text[site.locale].follow_label }}</strong></li>
+      <dt><strong>{{ site.data.ui-text[site.locale].follow_label }}</strong></dt>
     {% endif %}
     {% if site.twitter.username %}
-      <li><a href="https://twitter.com/{{ site.twitter.username }}"><i class="fa fa-fw fa-twitter-square" aria-hidden="true"></i> Twitter</a></li>
+      <dd><a href="https://twitter.com/{{ site.twitter.username }}"><i class="fa fa-fw fa-twitter-square" aria-hidden="true"></i> Twitter</a></dd>
     {% endif %}
     {% if site.facebook.username %}
-      <li><a href="https://facebook.com/{{ site.facebook.username }}"><i class="fa fa-fw fa-facebook-square" aria-hidden="true"></i> Facebook</a></li>
+      <dd><a href="https://facebook.com/{{ site.facebook.username }}"><i class="fa fa-fw fa-facebook-square" aria-hidden="true"></i> Facebook</a></dd>
     {% endif %}
     {% if site.author.github %}
-      <li><a href="http://github.com/{{ site.author.github }}"><i class="fa fa-fw fa-github" aria-hidden="true"></i> GitHub</a></li>
+      <dd><a href="http://github.com/{{ site.author.github }}"><i class="fa fa-fw fa-github" aria-hidden="true"></i> GitHub</a></dd>
     {% endif %}
     {% if site.author.bitbucket %}
-      <li><a href="http://bitbucket.org/{{ site.author.bitbucket }}"><i class="fa fa-fw fa-bitbucket" aria-hidden="true"></i> Bitbucket</a></li>
+      <dd><a href="http://bitbucket.org/{{ site.author.bitbucket }}"><i class="fa fa-fw fa-bitbucket" aria-hidden="true"></i> Bitbucket</a></dd>
     {% endif %}
-    <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | absolute_url }}{% endif %}"><i class="fa fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
-  </ul>
+    <dd><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | absolute_url }}{% endif %}"><i class="fa fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></dd>
+  </dl>
 </div>
 
 <div class="page__footer-copyright">Copyright &copy; {{ site.time | date: '%Y' }} Microsoft Corp.</div>

--- a/docs/_sass/minimal-mistakes/_footer.scss
+++ b/docs/_sass/minimal-mistakes/_footer.scss
@@ -53,14 +53,17 @@
 
 .page__footer-follow {
 
-  ul {
+  dl {
     margin: 0;
     padding: 0;
-    list-style-type: none;
+    display: flex;
+    flex-wrap: wrap;
   }
 
-  li {
+  dt,
+  dd {
     display: inline-block;
+    margin: 0 0 0.5em 0;
     padding-top: 5px;
     padding-bottom: 5px;
     font-family: $sans-serif-narrow;
@@ -68,7 +71,11 @@
     text-transform: uppercase;
   }
 
-  li + li:before {
+  dt {
+    padding-right: 10px;
+  }
+
+  dd + dd:before {
     content: "";
     padding-right: 5px;
   }


### PR DESCRIPTION
This changes semantic of footer section follow links to use data definition list which
allows to use element with header/label like purpose and list like elements. This allows
to not use the list element in soleley visual information - not as the list element itself.

Thanks!

Mocks rendered in browser:
![image](https://user-images.githubusercontent.com/14539/35301980-5d76253a-008d-11e8-9174-1dc9cf03812e.png)

The output from markup reader:

![image](https://user-images.githubusercontent.com/14539/35302055-8b2757f6-008d-11e8-82e2-80ca089b42e6.png)

Before:

![image](https://user-images.githubusercontent.com/14539/35302165-d2f01992-008d-11e8-9e74-c25413ecbbbe.png)
