### PR TITLE
:lipstick: Reverse order of applying border radius on mobile arch. items

### DIFF
--- a/docs/_sass/minimal-mistakes/_archive.scss
+++ b/docs/_sass/minimal-mistakes/_archive.scss
@@ -60,11 +60,15 @@
 }
 
 .archive__item-teaser {
-  border-radius: $border-radius $border-radius 0 0;
+  border-radius: $border-radius;
   overflow: hidden;
   text-align: center;
   img {
     width: 100%;
+  }
+
+  @include breakpoint($small) {
+    border-radius: $border-radius $border-radius 0 0;
   }
 }
 
@@ -131,6 +135,13 @@
     width: 100%;
     padding: 2em 1em;
     background: linear-gradient(180deg, rgba(#000, 0), #000);
+    border-bottom-left-radius: $border-radius;
+    border-bottom-right-radius: $border-radius;
+
+    @include breakpoint($small) {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
   }
 
   .archive__item-title {


### PR DESCRIPTION
This commit reverses logic of applying border radius to archive items - starting from
mobile first view - with all borders rounder and on the first breakpoint changing the borders to
top-only border used to render composed archive item cards in after $small breakpoint is hit.

Thanks!

Below are the screens with this small issue visible covering landing and projects page:

before (notice the non-rounded bottom borders):

![microsoft github io_azure-iot-developer-kit_docs_projects_ iphone x](https://user-images.githubusercontent.com/14539/35354103-699c52f0-0149-11e8-8e67-b8cf5510e266.png)
![microsoft github io_azure-iot-developer-kit_ iphone x](https://user-images.githubusercontent.com/14539/35354104-69cc4bea-0149-11e8-8185-bb5ccc60f13b.png)

After:

![localhost_4000_azure-iot-developer-kit_docs_projects_ iphone x](https://user-images.githubusercontent.com/14539/35354138-7f99d780-0149-11e8-91a0-f2751aea235f.png)
![localhost_4000_azure-iot-developer-kit_ iphone x](https://user-images.githubusercontent.com/14539/35354139-7fc4710c-0149-11e8-946e-ea777fe5657d.png)

![localhost_4000_azure-iot-developer-kit_docs_projects_ ipad](https://user-images.githubusercontent.com/14539/35354314-f2668c40-0149-11e8-8b2f-c2fa97553a2d.png)
![localhost_4000_azure-iot-developer-kit_docs_projects_ iphone x 1](https://user-images.githubusercontent.com/14539/35354315-f2878080-0149-11e8-8e9d-294ded3fc5f6.png)
