### PR TITLE
Move to scroll-to-top off the content

### DIFF
--- a/docs/_sass/extended/faq_menu.scss
+++ b/docs/_sass/extended/faq_menu.scss
@@ -23,12 +23,26 @@
   }
 
   a.faq-back-to-top {
+    $size: 52px;
     display: none;
     position: fixed;
-    height: 52px;
-    width: 52px;
-    bottom: 26px;
-    margin-left: 2.5423728814%;
+    height: $size;
+    width: $size;
+    bottom: $size;
+    right: $size;
+    // hit area round image
+    padding: $size/8;
+    box-sizing: content-box;
+    // slightly off-color by default
+    img {
+      opacity: .8;
+      transition: none;
+    }
+    // remove squared shadow from the circle shape
+    &:hover img {
+      box-shadow: none;
+      opacity: 1.0;
+    }
 
     @include breakpoint($large) {
       display: block;


### PR DESCRIPTION
This moves the trigger for scroll-to-top out of the main content on the
FAQ page.
The trigger itself is slightly modified to have better hit area (while retaining original visible size), to not
show shadow on hover (as the real shape is a sqaure while the content is an
icon within circle) and small visibility change on default state.

Thanks!

![image](https://user-images.githubusercontent.com/14539/35413140-caf790c0-021e-11e8-94df-e51da23d7f62.png)
