### PR TITLE
Use flex to layout archive item title links

### DIFF
--- a/docs/_sass/minimal-mistakes/_archive.scss
+++ b/docs/_sass/minimal-mistakes/_archive.scss
@@ -33,6 +33,8 @@
 }
 
 .archive__item-title {
+  display: flex;
+  justify-content: space-between;
   margin-bottom: 0.5em;
   font-family: $sans-serif-narrow;
 


### PR DESCRIPTION
This a working proposal to use predefined places for archive item/project item title links in static, predictable way.
The screenshoots attached shows how the permalink is sometimes displayed and how it could be layout after the PR is merged.

The first link is always expanded to take entire. This could be enforced by using `flex-grow`, but it seems not required as default behaviour for scaling seems fitted for the problem.

Thanks!

![20180130204730 1](https://user-images.githubusercontent.com/14539/35587713-dddee330-05fe-11e8-88eb-c5451b4419b1.jpg)
![20180130204744 1](https://user-images.githubusercontent.com/14539/35587712-ddab6f8c-05fe-11e8-8e0d-5e680e9aa6e2.jpg)

![20180130203419 1](https://user-images.githubusercontent.com/14539/35587529-618ff878-05fe-11e8-9597-1332f0a47728.jpg)

![20180130203441 1](https://user-images.githubusercontent.com/14539/35587513-54dcb8fa-05fe-11e8-84b0-e817fa518a41.jpg)

![20180130203255 1](https://user-images.githubusercontent.com/14539/35587562-743e86b0-05fe-11e8-8901-de4dd85a6a7c.jpg)

![20180130203315 1](https://user-images.githubusercontent.com/14539/35587560-740839d4-05fe-11e8-957d-6cb8c22a4821.jpg)
