### PR TITLE
Add missing focus ring to toggle menu

### DIFF
--- a/docs/_sass/minimal-mistakes/_navigation.scss
+++ b/docs/_sass/minimal-mistakes/_navigation.scss
@@ -244,6 +244,12 @@
     cursor: pointer;
   }
 
+  button {
+    &:focus {
+      @extend %tab-focus;
+    }
+  }
+
   .visible-links {
     display: -webkit-box;
     display: flex;


### PR DESCRIPTION
This is minor - it assign the same focus ring to toggle button
than used by other interactive elements (buttons/anchors).

I know it could be a problematic, but from the UX point of view, it's required. Some most respected websites use focus rings even on dropdown triggers

Thanks!

![20180208212539](https://user-images.githubusercontent.com/14539/35996574-303359a8-0d17-11e8-99f4-b03e4a4ac407.jpg)
