### PR TITLE
Correct vertical align of menu toggle

### DIFF
--- a/docs/_sass/minimal-mistakes/_navigation.scss
+++ b/docs/_sass/minimal-mistakes/_navigation.scss
@@ -288,7 +288,7 @@
     position: absolute;
     top: 100%;
     right: 0;
-    margin-top: 15px;
+    margin-top: 8px;
     padding: 5px;
     border: 1px solid $border-color;
     border-radius: $border-radius;

--- a/docs/_sass/minimal-mistakes/_utilities.scss
+++ b/docs/_sass/minimal-mistakes/_utilities.scss
@@ -229,7 +229,7 @@ body:hover .visually-hidden button {
    ========================================================================== */
 
 .navicon {
-  display: inline-block;
+  display: block;
   position: relative;
   width: $navicon-width;
   height: $navicon-height;


### PR DESCRIPTION
This moves the toggle button content into the middle of the
navigation bar. The hidden links offset for absolute positiioning
has been updated to reflect the visual vertical change

Thanks!

![image](https://user-images.githubusercontent.com/14539/35997003-7fbcc95e-0d18-11e8-8372-0a24618201a9.png)

![20180208205642](https://user-images.githubusercontent.com/14539/35996901-1b283b4a-0d18-11e8-8376-21fc4b64766b.jpg)
