### PR TITLE
Add textual context to Azure IoT catalog link. Closes #317

### DIFF
--- a/docs/_includes/page__hero.html
+++ b/docs/_includes/page__hero.html
@@ -79,7 +79,7 @@
 
         {% if page.header.extra_logo %}
           {% for extra in page.header.extra_logo %}
-            <a class="page__extra-logo" href="{{ extra.url }}" target="_blank" style="background: url({{ extra.image_path | absolute_url }});"></a>
+            <a class="page__extra-logo" href="{{ extra.url }}" target="_blank" style="background: url({{ extra.image_path | absolute_url }});"><span class="screen-reader-text">Azure Certified for IoT device catalog</span></a>
           {% endfor %}
         {% endif %}
       

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -229,7 +229,7 @@
 
       
         
-          <a class="page__extra-logo" href="https://catalog.azureiotsuite.com/details?title=MXChip-IoT-DevKit&source=home-page" target="_blank" style="background: url(https://microsoft.github.io/azure-iot-developer-kit/assets/images/logo-azure-certified.svg);"></a>
+          <a class="page__extra-logo" href="https://catalog.azureiotsuite.com/details?title=MXChip-IoT-DevKit&source=home-page" target="_blank" style="background: url(https://microsoft.github.io/azure-iot-developer-kit/assets/images/logo-azure-certified.svg);"><span class="screen-reader-text">Azure Certified for IoT device catalog</span></a>
         
       
     </div>


### PR DESCRIPTION
This PR allows crawlers and recommendation engines to correctly provide a link context. Or when using LUIS TTS there is a content provided.

Here is in text browser before:

![before](https://user-images.githubusercontent.com/14539/43050421-a62d2784-8e08-11e8-8ea8-116fade96efb.jpg)

and after (see the text popping up)

![after](https://user-images.githubusercontent.com/14539/43050424-ac2c66cc-8e08-11e8-973b-34aa7354b42f.jpg)


Thanks!