### PR TITLE
Fix arduino ide path for macOS in FAQ

### DIFF
--- a/docs/_docs/02-faq.md
+++ b/docs/_docs/02-faq.md
@@ -105,7 +105,7 @@ To resolvethis issue, please install the latest version of Arduino IDE [here](ht
     * macOS
 
         ```JSON
-        "arduino.path": "/Application",
+        "arduino.path": "/Applications",
         "arduino.additionalUrls": "https://raw.githubusercontent.com/VSChina/azureiotdevkit_tools/master/package_azureboard_index.json"
         ```
 


### PR DESCRIPTION
This is listed correctly other places in the docs, but I happened to try and copy/paste it from the FAQ which was singular instead of plural so didn't work.